### PR TITLE
개인페이지 방명록 css 클래스 수정

### DIFF
--- a/static/member_dark.css
+++ b/static/member_dark.css
@@ -7,7 +7,7 @@
 
 .about.dark > h4,
 .my_style.dark > h4,
-.hi > span {
+.hi.dark > span {
     color: #fefefe;
 }
 


### PR DESCRIPTION
다크모드 미적용시 제목 사라진 부분 CSS 수정했습니다.

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/82587107/199866402-8f42784f-dd05-4b3e-97cf-5d79267c6181.png">
